### PR TITLE
Properly find & use comedi and fftw3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,11 +11,13 @@ AC_PROG_CC
 AM_PROG_CC_STDC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL 
+
 AC_SEARCH_LIBS([pthread_create],[pthread])
 AC_SEARCH_LIBS([clock_gettime],[rt])
 AC_SEARCH_LIBS([sqrt],[m])
-AC_SEARCH_LIBS([fftw_execute],[fftw3]) # not working
-AC_SEARCH_LIBS([comedi_open],[libcomedi]) # not working
+PKG_CHECK_MODULES([COMEDI], [comedilib])
+PKG_CHECK_MODULES([FFTW3], [fftw3])
+
 AC_CHECK_HEADERS(stdlib.h string.h sys/time.h unistd.h comedi.h comedilib.h fftw3.h)
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([clock_gettime])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,17 @@
+
+AM_CPPFLAGS = \
+    $(COMEDI_CFLAGS) \
+    $(FFTW_CFLAGS)
+
 bin_PROGRAMS = laser_stimulation
-laser_stimulation_SOURCES = main.c comedi_code.c timespec_functions.c fftw_functions.c data_file_si.c main.h ../config.h
-laser_stimulation_LDADD =  -lcomedi 
+laser_stimulation_SOURCES = main.c \
+    comedi_code.c \
+    timespec_functions.c \
+    fftw_functions.c \
+    data_file_si.c \
+    main.h \
+    ../config.h
+
+laser_stimulation_LDADD = \
+    $(COMEDI_LIBS) \
+    $(FFTW3_LIBS)


### PR DESCRIPTION
This is using pkg-config macros to detect the libraries on the system
and to obtain the right CFLAGS and LDFLAGS for the respective system.

Pkg-config is pretty much present everywhere, so this dependency doesn't add any obstacle, and reliably fixes the link failures I had when trying to compile the project.
